### PR TITLE
Hide empty video and audio players

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,11 @@
     isolation: isolate;
   }
 
+  video, audio {
+    &:not([src]), &[src=""] {
+      display: none;
+    }
+  }
 }
 
 @layer base {


### PR DESCRIPTION
Before this the temporary anime themes player looked like it was broken before you actually started playing the opening