### PR TITLE
fix: 🩹 Don't save cache only fetch values to local cache

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -757,7 +757,9 @@ function cacheBuilder(settings) {
                     setLoading(false);
                   }
                   const cacheData = { ...evt.target.result, fromCache: true };
-                  localFetchCacheStorage.set(cacheData.cacheKey, cacheData);
+                  if (settings.type !== "only-if-cached") {
+                    localFetchCacheStorage.set(cacheData.cacheKey, cacheData);
+                  }
                   return saveMutate(cacheData);
                 }
               } 


### PR DESCRIPTION
Now search page sends cache only and fetch once requests, but because the cache only request will also save to local cache, the fetch once call thinks it's already fetched that one time. Will probably rework the fetch api later so this is just a fast fix