### PR TITLE
fix: 🐛 Add status back to fetch api

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -545,6 +545,8 @@ class Fetch {
       return null;
     }
 
+    this.status = response.status;
+
     if (!response.ok) {
       this.error = true;
       return this;


### PR DESCRIPTION
This was accidentally removed when refactoring fetch api