### PR TITLE
fix: 🐛 Make compare page more responsive

### DIFF
--- a/src/pages/ComparePage.jsx
+++ b/src/pages/ComparePage.jsx
@@ -494,9 +494,9 @@ function CompareMediaListContent() {
   );
 }
 
+const [cardsVisibility, storeCardsVisibility] = createStore([]);
 function ContentPage() {
   const { compareMediaList, users } = useCompareMediaList();
-  const [store, setStore] = createStore([]);
   const params = useParams();
   const observerList = [];
 
@@ -515,7 +515,7 @@ function ContentPage() {
   const options = { rootMargin: "500px" }
   const callback = (entries) => {
     for (const entry of entries) {
-      setStore(entry.target.dataset.index, entry.isIntersecting);
+      storeCardsVisibility(entry.target.dataset.index, entry.isIntersecting);
     }
   };
 
@@ -525,7 +525,7 @@ function ContentPage() {
     <For each={compareMediaList()}>{(media, i) => (
       <li use:observe attr:data-index={i()} class="pg-compare-media-card inline-container" style={{"--color": media.coverImage.color}}>
         <div class="wrapper">
-          <Show when={store[i()]}>
+          <Show when={cardsVisibility[i()]}>
             <Show when={media.bannerImage}>
               <img src={media.bannerImage} class="bg" inert alt="Background banner" />
             </Show>

--- a/src/pages/ComparePage.scss
+++ b/src/pages/ComparePage.scss
@@ -84,7 +84,6 @@
 
     &:not(.loading) {
       .cp-loader-circle {
-        transition-delay: .2s;
         opacity: 0;
         visibility: hidden;
       }
@@ -100,8 +99,15 @@
       --loader-border-size: .5rem;
     }
 
-    &.loading .pg-compare-media-card {
-      opacity: .5;
+    &.loading {
+      .cp-loader-circle {
+        transition-delay: .2s;
+      }
+
+      .pg-compare-media-card {
+        opacity: .5;
+        transition-delay: .2s;
+      }
     }
   }
 

--- a/src/pages/ComparePage.scss
+++ b/src/pages/ComparePage.scss
@@ -113,6 +113,7 @@
       isolation: isolate;
       display: grid;
       grid-template-columns: auto 1fr;
+      min-height: 16rem;
       height: 16rem;
       padding: .5rem;
       border-radius: .5rem;


### PR DESCRIPTION
- The page struggled to display more than 600 cards but now it should handle at least over 2k easily
  - I didn't test more than 2500, but that should be plenty
- Also optimized how the loading animation is shown
  - Most of the time you should never see the loading animation if you are not on mobile or on a really slow device