### PR TITLE
fix: 🩹 Try to fetch data again after 500 error

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -545,11 +545,17 @@ class Fetch {
         const response = await this.#sendRequest();
 
         if (response.status === 429) {
-          console.warn('429 received, backing off...', this.url);
+          console.warn("429 received, backing off...", this.url);
           const time = (parseInt(response.headers.get("Retry-After")) || bucket.getDefaultDelay());
           await new Promise(res => setTimeout(res, time * 1000));
           continue;
-        } 
+        }
+
+        if (response.status === 500 && this.url.includes("anilist")) {
+          console.warn("500 received, the request was probably fine, but anilist has lot of traffic. Resend after 2 seconds");
+          await new Promise(res => setTimeout(res, 2000));
+          continue;
+        }
 
         return response;
       }


### PR DESCRIPTION
- Not sure why this happens but sometimes anilist will just decide that the request was "500 bad request" even when the request was fine
- Added a fallback to the old api that tries to fetch the data again if the status was 500, because in every case I have seen so far the request is actually not bad, but just somehow was rejected. Usually when you try to fetch the data again it will go through