### PR TITLE
chore: 🧦 Change Twitter hashtag link to Nitter

### DIFF
--- a/src/components/media/ExternalLinks.jsx
+++ b/src/components/media/ExternalLinks.jsx
@@ -11,7 +11,7 @@ export default function ExternalLinks(props) {
           <ul>
             <Show when={props.hashtag}>
               <li>
-                <a href={`https://x.com/search?q=${props.hashtag}&src=typd`} target="_blank">{props.hashtag}</a>
+                <a href={`https://nitter.net/search?q=${props.hashtag.replaceAll("#", "%23")}`} target="_blank">{props.hashtag}</a>
               </li>
             </Show>
             <For each={props.externalLinks}>{link => (


### PR DESCRIPTION
Nitten just seems to load faster, doesn't need logging in and provides more search options so this just seems like a no brainer. I also don't use twitter to this is more convinient for me :D