### PR TITLE
fix: 🐛 Media page coult overflow watch episodes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -207,6 +207,10 @@
     }
   }
 
+  .no-overflow {
+    overflow: hidden;
+  }
+
   .grid-column-auto-fill {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(min(100%, max(var(--grid-column-width, 20rem), 100% / var(--grid-max-column-count, 999) - var(--gap, .5rem))), 1fr));

--- a/src/pages/MediaInfo.jsx
+++ b/src/pages/MediaInfo.jsx
@@ -334,7 +334,7 @@ export function MediaPageRedirect() {
 function StreamingEpisodes(props) {
   return (
     <Show when={props.streamingEpisodes?.length}>
-      <div class="media-page-watch-episodes">
+      <div class="no-overflow media-page-watch-episodes">
         <h2>Watch</h2>
         <ol class="grid-reel-auto-fill">
           <For each={props.streamingEpisodes}>{episode => (


### PR DESCRIPTION
- If series has many episodes like HxH the watch episodes would prevent the page from scaling down to mobile