### PR TITLE
Feature/display global scores on mal media cards

### DIFF
--- a/src/collections/collections.js
+++ b/src/collections/collections.js
@@ -8,3 +8,4 @@ export * as modes from "./modes.js";
 export * as queries from "./querys.js";
 export * as signals from "./signals.js";
 export * as requests from "./requests/requests.js";
+export * as globalState from "../context/global.js";

--- a/src/collections/fetchers/anilist.js
+++ b/src/collections/fetchers/anilist.js
@@ -15,6 +15,18 @@ export const activityPageless = (token, variables) => {
 export const getMediaById = (token, id) => {
   return fetcherTemplates.anilistAuth(token, queries.anilistMediaById, { id }, res => res.data.Media);
 };
+
+export const getMediasWithIds = (token, variables) => {
+  asserts.assertTrue(variables.id_in || variables.idMal_in, "Missing list for ids");
+  const count = variables.id_in?.length || variables.idMal_in?.length;
+  if (!count) {
+    return;
+  }
+
+
+  return fetcherTemplates.anilistAuth(token, queries.anilistGetMediasWithIds(count), variables, res => Object.values(res.data).map(page => page.media).flat());
+};
+
 export const getRecommendationsByid = (token, id, page = 1) => {
   return fetcherTemplates.anilistAuth(token, queries.anilistRecommendationsById, { id, page }, res => res.data.Media.recommendations);
 };

--- a/src/collections/querys.js
+++ b/src/collections/querys.js
@@ -951,10 +951,10 @@ const anilistGetUserMediaStaff = type => format`query ($name: String) {
 export const anilistGetUserMangaStaff = anilistGetUserMediaStaff("manga");
 export const anilistGetUserAnimeStaff = anilistGetUserMediaStaff("anime");
 
-export const anilistGetMediaIds = ids => format`query ($ids: [Int]) {
-  ${[...Array(Math.ceil(ids.length / 50))].map((_, i) => {
+export const anilistGetMediasWithIds = count => format`query ($type: MediaType, $id_in: [Int], $idMal_in: [Int]) {
+  ${[...Array(Math.ceil(count / 50))].map((_, i) => {
     return `page${i + 1}: Page(page: ${i + 1}) {
-      media(id_in: $ids) {
+      media(type: $type, id_in: $id_in, idMal_in: $idMal_in) {
         ...media
       }
     }`;
@@ -963,6 +963,7 @@ export const anilistGetMediaIds = ids => format`query ($ids: [Int]) {
 
 fragment media on Media {
   id
+  idMal
   type
   bannerImage
   title {

--- a/src/components/Cards.jsx
+++ b/src/components/Cards.jsx
@@ -1,6 +1,6 @@
 import { A } from "@solidjs/router";
-import { asserts, localizations } from "../collections/collections";
-import { arrayUtils, urlUtils } from "../utils/utils";
+import { asserts, globalState } from "../collections/collections";
+import { urlUtils } from "../utils/utils";
 import Edit from "../assets/Edit";
 import Planning from "../assets/Planning";
 import Watching from "../assets/Watching";
@@ -45,49 +45,96 @@ function AnilistMediaCardListBody(props) {
   )
 }
 
+function JikanMediaCardListBody(props) {
+  asserts.assertTrue(props.media, "Missing media");
+
+  return (
+    <li class="cp-media-card inline-container">
+      <A class="clean-link" href={urlUtils.jikanMediaUrl(props.type, props.media)}>
+        <div class="wrapper">
+          <img class="absolute-inset" src={props.media.images.webp.image_url} alt="Cover." />
+          <Show when={props.media.score}>
+            <div class="score">
+              <Star /> {(props.media.score)}
+            </div>
+          </Show>
+          {props.children}
+        </div>
+        <p class="line-clamp">
+          <Switch>
+            <Match when={props.media.titles.English}>{props.media.titles.English}</Match>
+            <Match when={props.media.titles.Default}>{props.media.titles.Default}</Match>
+          </Switch>
+        </p>
+      </A>
+    </li>
+  )
+}
+
 export function AnilistMediaCard(props) {
   asserts.assertTrue(props.media, "Missing media");
 
+  return (
+    <AnilistMediaCardListBody {...props}>
+      <QuickActionItemList {...props} />
+    </AnilistMediaCardListBody>
+  );
+}
+
+export function JikanMediaCard(props) {
+  asserts.assertTrue(props.media, "Missing media");
+  asserts.isTypeString(props.type);
+
+  return (
+    <JikanMediaCardListBody {...props}>
+      <Show when={globalState.mediaWithMalId[props.media.mal_id]}>
+        <QuickActionItemList media={globalState.mediaWithMalId[props.media.mal_id]} />
+      </Show>
+    </JikanMediaCardListBody>
+  );
+}
+
+function QuickActionItemList(props) {
   const { openEditor } = useEditMediaEntries();
   const { accessToken } = useAuthentication();
 
+  asserts.assertTrue(props.media, "Missing media");
+
   return (
-    <AnilistMediaCardListBody {...props}>
-      <Show when={accessToken()}>
-        <ul class="cp-media-card-quick-action-items">
-          <QuickActionListButton label="Edit media" onClick={e => {
-            e.preventDefault();
-            openEditor(props.media);
-          }}>
-            <Edit />
-          </QuickActionListButton>
-          <QuickActionListButton label="Set to planning" onClick={e => {
-            e.preventDefault();
-            api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "PLANNING" });
-          }}>
-            <Planning />
-          </QuickActionListButton>
-          <QuickActionListButton label={"Set to " + (props.media.type === "ANIME" ? "watching" : "reading")} onClick={e => {
-            e.preventDefault();
-            api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "CURRENT" });
-          }}>
-            <Watching />
-          </QuickActionListButton>
-          <QuickActionListButton label="Set to completed" onClick={e => {
-            e.preventDefault();
-            api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "COMPLETED" });
-          }}>
-            <Complete />
-          </QuickActionListButton>
-          <QuickActionListButton label={"Set to " + (props.media.type === "ANIME" ? "rewatching" : "rereading")} onClick={e => {
-            e.preventDefault();
-            api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "REPEAT" });
-          }}>
-            <Rewatched />
-          </QuickActionListButton>
-        </ul>
-      </Show>
-    </AnilistMediaCardListBody>
+    <Show when={accessToken()}>
+      <ul class="cp-media-card-quick-action-items">
+        <QuickActionListButton label="Edit media" onClick={e => {
+          e.preventDefault();
+          openEditor(props.media);
+        }}>
+          <Edit />
+        </QuickActionListButton>
+        <QuickActionListButton label="Set to planning" onClick={e => {
+          e.preventDefault();
+          api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "PLANNING" });
+        }}>
+          <Planning />
+        </QuickActionListButton>
+        <QuickActionListButton label={"Set to " + (props.media.type === "ANIME" ? "watching" : "reading")} onClick={e => {
+          e.preventDefault();
+          api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "CURRENT" });
+        }}>
+          <Watching />
+        </QuickActionListButton>
+        <QuickActionListButton label="Set to completed" onClick={e => {
+          e.preventDefault();
+          api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "COMPLETED" });
+        }}>
+          <Complete />
+        </QuickActionListButton>
+        <QuickActionListButton label={"Set to " + (props.media.type === "ANIME" ? "rewatching" : "rereading")} onClick={e => {
+          e.preventDefault();
+          api.anilist.mutateMedia(accessToken(), { mediaId: props.media.id, status: "REPEAT" });
+        }}>
+          <Rewatched />
+        </QuickActionListButton>
+      </ul>
+    </Show>
   );
 }
 

--- a/src/context/global.js
+++ b/src/context/global.js
@@ -1,0 +1,3 @@
+import { createStore } from "solid-js/store";
+
+export const [mediaWithMalId, storeMediaWithMalId] = createStore({});

--- a/src/pages/MediaInfoCharactersJikan.jsx
+++ b/src/pages/MediaInfoCharactersJikan.jsx
@@ -2,7 +2,7 @@ import { useParams } from "@solidjs/router";
 import { useMediaInfo } from "../context/providers";
 import { fetchers, fetcherSenders, localizations, requests, signals } from "../collections/collections";
 import { fetcherSenderUtils } from "../utils/utils";
-import { createMemo, createSignal } from "solid-js";
+import { createMemo } from "solid-js";
 import { MalCharacterCard } from "../components/Cards.jsx";
 
 export function MediaInfoCharactersJikan() {

--- a/src/pages/User/Stats/Genres.jsx
+++ b/src/pages/User/Stats/Genres.jsx
@@ -5,6 +5,8 @@ import { createEffect, createSignal, on } from "solid-js";
 import "./Genres.scss";
 import { createStore, reconcile } from "solid-js/store";
 import { useAuthentication, useUser } from "../../../context/providers";
+import { fetcherSenderUtils } from "../../../utils/utils";
+import { fetchers, fetcherSenders } from "../../../collections/collections";
 
 export function StatsAnimeGenres() {
   const params = useParams();
@@ -35,7 +37,9 @@ function StatsGenres(props) {
   const [mediaIds, setMediaIds] = createSignal(new Set());
   const [state, setState] = createSignal("count");
   const { user } = useUser();
-  const [mediaById, { mutate }] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById, { mutate }] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [store, setStore] = createStore({});
 
   createEffect(on(() => props.genres, genres => {
@@ -121,7 +125,9 @@ function Cards(props) {
   const params = useParams();
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
 
   let fetchNewCards = false;
   createEffect(on(() => props.mediaIds, () => {

--- a/src/pages/User/Stats/Staff.jsx
+++ b/src/pages/User/Stats/Staff.jsx
@@ -5,6 +5,8 @@ import { createEffect, createSignal, on } from "solid-js";
 import "./Genres.scss";
 import { createStore, reconcile } from "solid-js/store";
 import { useAuthentication } from "../../../context/providers";
+import { fetcherSenderUtils } from "../../../utils/utils";
+import { fetchers, fetcherSenders } from "../../../collections/collections";
 
 export function StatsAnimeStaff() {
   const params = useParams();
@@ -34,7 +36,9 @@ function StatsStaff(props) {
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
   const [state, setState] = createSignal("count");
-  const [mediaById, { mutate }] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById, { mutate }] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [store, setStore] = createStore({});
 
   createEffect(on(() => props.genres, genres => {
@@ -119,7 +123,9 @@ function Cards(props) {
   const params = useParams();
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
 
   let fetchNewCards = false;
   createEffect(on(() => props.mediaIds, () => {

--- a/src/pages/User/Stats/Studios.jsx
+++ b/src/pages/User/Stats/Studios.jsx
@@ -5,6 +5,8 @@ import { createEffect, createSignal, on } from "solid-js";
 import "./Genres.scss";
 import { createStore, reconcile } from "solid-js/store";
 import { useAuthentication } from "../../../context/providers";
+import { fetcherSenderUtils } from "../../../utils/utils";
+import { fetchers, fetcherSenders } from "../../../collections/collections";
 
 export function StatsAnimeStudios() {
   const params = useParams();
@@ -23,7 +25,9 @@ function StatsStudios(props) {
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
   const [state, setState] = createSignal("count");
-  const [mediaById, { mutate }] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById, { mutate }] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [store, setStore] = createStore({});
 
   createEffect(on(() => props.genres, genres => {
@@ -105,7 +109,9 @@ function Cards(props) {
   const params = useParams();
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
 
   let fetchNewCards = false;
   createEffect(on(() => props.mediaIds, () => {

--- a/src/pages/User/Stats/Tags.jsx
+++ b/src/pages/User/Stats/Tags.jsx
@@ -5,6 +5,8 @@ import { createEffect, createSignal, on } from "solid-js";
 import "./Genres.scss";
 import { createStore, reconcile } from "solid-js/store";
 import { useAuthentication, useUser } from "../../../context/providers";
+import { fetcherSenderUtils, fetcherUtils } from "../../../utils/utils";
+import { fetchers, fetcherSenders } from "../../../collections/collections";
 
 export function StatsAnimeTags() {
   const params = useParams();
@@ -35,7 +37,8 @@ function StatsTags(props) {
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
   const [state, setState] = createSignal("count");
-  const [mediaById, { mutate }] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, () => ({ id_in: [...mediaIds()] }));
+  const [mediaById, { mutate }] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [store, setStore] = createStore({});
 
   createEffect(on(() => props.genres, genres => {
@@ -121,7 +124,8 @@ function Cards(props) {
   const params = useParams();
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, () => ({ id_in: [...mediaIds()] }));
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
 
   let fetchNewCards = false;
   createEffect(on(() => props.mediaIds, () => {

--- a/src/pages/User/Stats/VoiceActors.jsx
+++ b/src/pages/User/Stats/VoiceActors.jsx
@@ -5,6 +5,8 @@ import { createEffect, createSignal, on } from "solid-js";
 import "./Genres.scss";
 import { createStore, reconcile } from "solid-js/store";
 import { useAuthentication } from "../../../context/providers";
+import { fetchers, fetcherSenders } from "../../../collections/collections";
+import { fetcherSenderUtils } from "../../../utils/utils";
 
 export function StatsAnimeVoiceActors() {
   const params = useParams();
@@ -25,7 +27,9 @@ function StatsVoiceActors(props) {
   const [characterIds, setCharacterIds] = createSignal(new Set());
   const [state, setState] = createSignal("count");
   const [pageType, setPageType] = createSignal("media");
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 && pageType() === "media" ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => pageType() === "media" ? ({ id_in: [...mediaIds()] }) : undefined;
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [characterById] = api.anilist.characterIds(() => characterIds().size > 0 && pageType() === "characters" ? [...characterIds()] : undefined, accessToken);
   const [mediaStore, setMediaStore] = createStore({});
   const [characterStore, setCharacterStore] = createStore({});
@@ -133,7 +137,9 @@ function Cards(props) {
   const { accessToken } = useAuthentication();
   const [mediaIds, setMediaIds] = createSignal(new Set());
   const [characterIds, setCharacterIds] = createSignal(new Set());
-  const [mediaById] = api.anilist.mediaIds(() => mediaIds().size > 0 ? [...mediaIds()] : undefined, accessToken);
+  const mediaVariable = () => ({ id_in: [...mediaIds()] });
+  const fetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediasWithIds, accessToken, mediaVariable);
+  const [mediaById] = fetcherSenders.sendWithNullUpdates(fetcher);
   const [characterById] = api.anilist.characterIds(() => characterIds().size > 0 ? [...characterIds()] : undefined, accessToken);
   let gridReel;
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -188,9 +188,6 @@ const api = {
     userMangaStaff: reloadCache((name, token) => {
       return Fetch.authAnilist(token, queries.anilistGetUserMangaStaff, { name }, res => res.data.User.statistics.manga.staff);
     }),
-    mediaIds: fetchOnce((ids, token) => {
-      return Fetch.authAnilist(token, queries.anilistGetMediaIds(ids), { ids }, res => Object.values(res.data).map(page => page.media).flat());
-    }),
     characterIds: fetchOnce((ids, token) => {
       return Fetch.authAnilist(token, queries.anilistGetCharacterIds(ids), { ids }, res => Object.values(res.data).map(page => page.characters).flat());
     }),


### PR DESCRIPTION
- Added global average scores to MyAnimeList media cards
- Added Anilist quick action buttons for search media cards
  - If the id is missing from AniList db the quick action menu will not be shown
- Refactored old endpoint to support MyAnimeList id searches and updated the code to use fetcher API v4



## Before:
<img width="908" height="352" alt="image" src="https://github.com/user-attachments/assets/67c542f5-fd2f-42fa-a6b3-b56b827cd453" />

## After:
<img width="899" height="351" alt="image" src="https://github.com/user-attachments/assets/4b5bc0c1-0f97-4cb9-90fe-a51676ed04c1" />
