### PR TITLE
rework: 🛠️ Allow fetcher to update response to undefined

### DIFF
--- a/src/collections/fetcherSenders.js
+++ b/src/collections/fetcherSenders.js
@@ -203,8 +203,14 @@ const sendGeneric = (cacheTypeSignal, disableNullValues, senderDisabledSignal, e
   });
 
   createRenderEffect(() => {
+    if (isDisabled()) {
+      return;
+    };
+
     const fetcher = fetcherSignal();
-    if (!fetcher || isDisabled()) {
+    if (!fetcher) {
+      currentFetcher = null;
+      setResponse(undefined);
       return;
     };
 

--- a/src/collections/fetchers/jikan.js
+++ b/src/collections/fetchers/jikan.js
@@ -21,8 +21,8 @@ export const getCharactersByMediaId = (type, id) => {
 export const getStaffByMediaId = (type, id) => {
   asserts.isTypeString(type, "type");
   asserts.isInteger(id, "id");
-  switch (type) {
-    case localizations.anime: return fetcherTemplates.getJSON(queries.myAnimeListAnimeStaffById(id), res => res.data);
-    case localizations.manga: return fetcherTemplates.getJSON(queries.myAnimeListMangaStaffById(id), res => res.data);
+
+  if (type === localizations.anime) {
+    return fetcherTemplates.getJSON(queries.myAnimeListAnimeStaffById(id), res => res.data);
   }
 };

--- a/src/collections/querys.js
+++ b/src/collections/querys.js
@@ -358,7 +358,6 @@ export const myAnimeListMangaById = id => `https://api.jikan.moe/v4/manga/${id}/
 export const myAnimeListAnimeCharactersById = id => `https://api.jikan.moe/v4/anime/${id}/characters`;
 export const myAnimeListMangaCharactersById = id => `https://api.jikan.moe/v4/manga/${id}/characters`;
 export const myAnimeListAnimeStaffById = id => `https://api.jikan.moe/v4/anime/${id}/staff`;
-export const myAnimeListMangaStaffById = id => `https://api.jikan.moe/v4/manga/${id}/staff`;
 export const myAnimeListMediaSearch = (type, query) => `https://api.jikan.moe/v4/${type}?${query}`;
 export const myAnimeListMediaGenres = (type) => `https://api.jikan.moe/v4/genres/${type}`;
 

--- a/src/collections/requests/jikan.js
+++ b/src/collections/requests/jikan.js
@@ -3,6 +3,7 @@ import { batch, createSignal } from "solid-js";
 export const addPendingRequest = () => {
   batch(() => {
     setInOneSeconds(v => v + 1);
+    setInTwoSeconds(v => v + 1);
     setInFiveSeconds(v => v + 1);
     setInTenSeconds(v => v + 1);
   });
@@ -30,12 +31,14 @@ export const removeFromWaitingQueue = () => {
 
 export const removePendingRequest = () => {
   setTimeout(() => setInOneSeconds(v => v - 1), 1_000);
+  setTimeout(() => setInTwoSeconds(v => v - 1), 2_000);
   setTimeout(() => setInFiveSeconds(v => v - 1), 5_000);
   setTimeout(() => setInTenSeconds(v => v - 1), 10_000);
 }
 
 const [inOneSeconds, setInOneSeconds] = createSignal(0);
+const [inTwoSeconds, setInTwoSeconds] = createSignal(0);
 const [inFiveSeconds, setInFiveSeconds] = createSignal(0);
 const [inTenSeconds, setInTenSeconds] = createSignal(0);
 
-export { inOneSeconds, inFiveSeconds, inTenSeconds };
+export { inOneSeconds, inTwoSeconds, inFiveSeconds, inTenSeconds };

--- a/src/pages/MediaInfoJikan.jsx
+++ b/src/pages/MediaInfoJikan.jsx
@@ -19,7 +19,8 @@ export function MediaInfoWrapperJikan(props) {
   const { accessToken } = useAuthentication();
 
   const jikanFetcher = fetcherSenderUtils.createFetcher(fetchers.jikan.getMediaById, () => params.type, () => params.id);
-  const [jikanData] = fetcherSenders.sendWithNullUpdates(jikanFetcher);
+  const cacheType = fetcherSenderUtils.createDynamicCacheType({ "only-if-cached": () => requests.jikan.inOneSeconds() })
+  const [jikanData] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(cacheType, jikanFetcher);
 
   const anilistFetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediaByTypeAndMalId, accessToken, () => params.type, () => params.id);
   const [anilistData, { mutateBoth: mutateBothAnilistData }] = fetcherSenders.sendWithNullUpdates(anilistFetcher);
@@ -162,11 +163,12 @@ export function MediaInfoHomeJikan() {
   const { jikanData } = useMediaInfo();
 
   const jikanCharacterFetcher = fetcherSenderUtils.createFetcher(fetchers.jikan.getCharactersByMediaId, () => params.type, () => params.id);
-  const cacheType = fetcherSenderUtils.createDynamicCacheType({ "only-if-cached": () => requests.jikan.inOneSeconds() > 0 })
-  const [jikanCharactersData] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(cacheType, jikanCharacterFetcher);
+  const characterCacheType = fetcherSenderUtils.createDynamicCacheType({ "only-if-cached": () => requests.jikan.inOneSeconds() || jikanData.loading })
+  const [jikanCharactersData] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(characterCacheType, jikanCharacterFetcher);
 
   const jikanStaffFetcher = fetcherSenderUtils.createFetcher(fetchers.jikan.getStaffByMediaId, () => params.type, () => params.id);
-  const [jikanStaffData] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(cacheType, jikanStaffFetcher);
+  const staffCacheType = fetcherSenderUtils.createDynamicCacheType({ "only-if-cached": () => requests.jikan.inTwoSeconds() || jikanCharactersData.loading})
+  const [jikanStaffData] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(staffCacheType, jikanStaffFetcher);
 
   return (
     <>

--- a/src/utils/fetcherSenderUtils.js
+++ b/src/utils/fetcherSenderUtils.js
@@ -22,7 +22,7 @@ const createFetcherWithArguments = (fetcherCreator, args) => {
  * @param {(any) => Fetcher} fetcherCreator
  */
 export const createFetcher = (fetcherCreator, ...args) => {
-  return createMemo(prev => createFetcherWithArguments(fetcherCreator, args) ?? prev);
+  return createMemo(() => createFetcherWithArguments(fetcherCreator, args));
 }
 
 


### PR DESCRIPTION
- Previously fetcher could only be undefined when initialized with wrong params, so when it got valid params it could not ever be nullish again
- This was by choice to make it easier to "disable" fetchers with undefined param values
  - undefined params values would return undefined fetcher which would not be set if previous fetcher was defined
  - Now fetcherSender supports an actual disable signal so this should not be needed anymore
- This will make it easier for me to remove data that is not fetchable for example MyAnimeList staff info for manga
- I don't know if this has any unseen side effects so I need to test this a bit but this should make the code more readable and more clear when feather is disabled and when not