### PR TITLE
fix: 🐛 Characters page would refetch when changing language

### DIFF
--- a/src/pages/Entities.jsx
+++ b/src/pages/Entities.jsx
@@ -198,7 +198,9 @@ function CharactersPage(props) {
     const nextPage = untrack(hasNextPage);
     const pageCount = Math.ceil(props.cache.length / hardcodedPageCount)
 
-    if (visiblePages.has(pageCount) && nextPage) {
+    if (visiblePages.has(pageCount) && !freshPages.has(pageCount)) {
+      return pageCount;
+    } else if (visiblePages.has(pageCount) && nextPage && freshPages.has(pageCount)) {
       return pageCount + 1;
     } else {
       const notFreshPages = [...visiblePages.difference(freshPages)].sort((a, b) => b - a);


### PR DESCRIPTION
If your characters list was shorter than one page (25 entries) the initial fetch would be to page 2. So the first page would not ever be fetched and then after the character cards would be rerendered after language change the initial page would fetch which would reset your language setting.

The code needs a propel refactoring sometime later, but this was a quick fix.

This fix will still cause a bug if your screen is 4k or over and the media entry has maybe 2 or 3 pages of characters. The initial fetch would then be page 3 and if the user changes the language after that when the first page gets fetched later the language setting will reset again.