### PR TITLE
feat: ✨ Add search param to search anilist media with mal id

### DIFF
--- a/src/collections/fetchers/anilist.js
+++ b/src/collections/fetchers/anilist.js
@@ -12,7 +12,11 @@ export const activityPageless = (token, variables) => {
   return fetcherUtils.changeCacheType(fetcher, localizations.onlyIfCached);
 };
 
-export const getMediaById = (token, id) => {
+export const getMediaById = ({ token, id, isMalId, type }) => {
+  if (isMalId) {
+    return getMediaByTypeAndMalId(token, type, id);
+  }
+
   return fetcherTemplates.anilistAuth(token, queries.anilistMediaById, { id }, res => res.data.Media);
 };
 

--- a/src/pages/MediaPageAnilist/index(media-page-anilist).scoped.jsx
+++ b/src/pages/MediaPageAnilist/index(media-page-anilist).scoped.jsx
@@ -1,4 +1,4 @@
-import {Navigate, useLocation, useNavigate, useParams} from "@solidjs/router";
+import {Navigate, useLocation, useNavigate, useParams, useSearchParams} from "@solidjs/router";
 import {AnilistRelationsPreview} from "./RelationsPreview.scoped.jsx";
 import Characters from "../../components/media/Characters.jsx";
 import {
@@ -27,13 +27,15 @@ import {ExtraInfo} from "../../components/media/ExtraInfo.scoped.jsx";
 import {ExternalLinks} from "../../components/media/ExternalLinks.scoped.jsx";
 import { MediaPageScores } from "../../components/MediaPage/Scores.scoped.jsx";
 import "./index(media-page-anilist).scoped.css";
+import { fetchers } from "../../collections/collections.js";
 
 export function MediaInfoContent(props) {
   const params = useParams();
+  const [searchParams] = useSearchParams();
   const { accessToken } = useAuthentication();
   const [isFavourite, setIsFavourite] = createSignal();
 
-  const anilistFetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediaById, accessToken, () => params.id);
+  const anilistFetcher = fetcherSenderUtils.createFetcher(fetchers.anilist.getMediaById, () => ({ token: accessToken(), id: params.id, isMalId: searchParams.isMalId != null, type: params.type }));
   const cacheType = fetcherSenderUtils.createDynamicCacheType({ default: () => requests.anilist.inFiveSeconds() > 2 })
   const [anilistData, { mutateBoth: mutateBothAnilistData }] = fetcherSenders.sendWithCacheTypeWithoutNullUpdates(cacheType, anilistFetcher);
 
@@ -120,7 +122,7 @@ export function MediaInfoContent(props) {
               <img src={anilistData()?.data?.coverImage.large} alt="Cover" class="media-page-cover" />
               <div class="cp-media-api-switcher">
                 <Show when={anilistData()?.data.id}>
-                  <a href={"https://anilist.co/" + params.type + "/" + params.id} target="_black" class="active">
+                  <a href={"https://anilist.co/" + params.type + "/" + (anilistData()?.data.id ?? params.id)} target="_black" class="active">
                     <span class="visually-hidden">Go to Anilist</span>
                     <Anilist />
                     <ExternalSource />


### PR DESCRIPTION
- If you add `?isMalId` to your url, the id used will be mall
- This can make it quicker to convert mal urls to LOB urls
- MAL: https://myanimelist.net/anime/59978/Sousou_no_Frieren_2nd_Season
- Becomes: https://kassu11.github.io/legendary-octo-barnacle/ani/anime/59978/frieren?isMalId
- Note that this id is not a valid Anilist id, but it will still work